### PR TITLE
chore: ignore the dumbest Dockerfile test ever

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,6 @@
+---
+ignored:
+  - DL3018 # this is one of the dumbest rules I've ever seen. Alpine doesn't
+           # keep multiple versions of packages around, so pinning to a
+           # specific version is just a recipe for having to constantly update
+           # the versions in your Dockerfile


### PR DESCRIPTION
I would really like to know who thought it was a good idea to default
this test to on